### PR TITLE
Use release year instead of production year + some tests to avoid PHP warnings/notices

### DIFF
--- a/lib/Info/Movie/SearchResult.php
+++ b/lib/Info/Movie/SearchResult.php
@@ -46,6 +46,12 @@ class SearchResult
     public $releaseDate;
 
     /**
+     * Year the movie was released
+     * @var string
+     */
+    public $releaseYear;
+
+    /**
      * Short list of directors (names only)
      * @var array(string)
      */

--- a/lib/mkvmanager/scraper_allocine.php
+++ b/lib/mkvmanager/scraper_allocine.php
@@ -84,6 +84,8 @@ class MkvManagerScraperAllocine extends MkvManagerScraper
         $result->score = (float)$doc->statistics->pressRating + (float)$doc->statistics->userRating;
 
         // actors
+        if( isset( $doc->casting->castMember ) )
+        {
         foreach( $doc->casting->castMember as $person )
         {
             if ( (string)$person->picture['href'] == '' )
@@ -112,12 +114,18 @@ class MkvManagerScraperAllocine extends MkvManagerScraper
                 continue;
             }
         }
+        }
 
+        if( isset( $doc->genreList->genre ) )
+        {
         foreach( $doc->genreList->genre as $genre )
         {
             $result->genre[] = (string)$genre;
         }
+        }
 
+        if( isset( $doc->mediaList->media ) )
+        {
         foreach( $doc->mediaList->media as $media )
         {
             if ( (string)$media['class'] == 'picture' )
@@ -153,6 +161,7 @@ class MkvManagerScraperAllocine extends MkvManagerScraper
                     $result->trailers[] = $trailerObject;
                 }
             }
+        }
         }
 
         return $result;

--- a/lib/mkvmanager/scraper_allocine.php
+++ b/lib/mkvmanager/scraper_allocine.php
@@ -41,6 +41,7 @@ class MkvManagerScraperAllocine extends MkvManagerScraper
             $result->title = (string)$movie->title;
             $result->productionYear = (int)$movie->productionYear;
             $result->releaseDate = (string)$movie->release->releaseDate;
+            $result->releaseYear = $movie->release->releaseDate == "" ? (int)$movie->productionYear : substr( $movie->release->releaseDate, 0, 4 );
             $result->directorsShort = explode(', ', (string)$movie->castingShort->directors );
             $result->actorsShort = explode( ', ', (string)$movie->castingShort->actors );
 

--- a/lib/mkvmanager/scraper_tmdb.php
+++ b/lib/mkvmanager/scraper_tmdb.php
@@ -38,6 +38,7 @@ class MkvManagerScraperTMDB extends MkvManagerScraper
             $result->title = (string)$movie->name;
             $result->productionYear = (int)$movie->released;
             $result->releaseDate = (string)$movie->released;
+            $result->releaseYear = substr( $movie->released, 0, 4 );
             $result->url = (string)$movie->url;
 
             foreach( $movie->images->image as $image )

--- a/lib/mkvmanager/scraper_tmdb.php
+++ b/lib/mkvmanager/scraper_tmdb.php
@@ -79,6 +79,8 @@ class MkvManagerScraperTMDB extends MkvManagerScraper
         }
 
         $result = array();
+        if( isset( $doc->movies->movie->images->backdrop ))
+        {
         foreach( $doc->movies->movie->images->backdrop as $image )
         {
             $imageObject = new mm\Info\Image;
@@ -99,7 +101,9 @@ class MkvManagerScraperTMDB extends MkvManagerScraper
             }
             $result[] = $imageObject;
         }
-
+        }
+        if( isset( $doc->movies->movie->images->poster ))
+        {
         foreach( $doc->movies->movie->images->poster as $image )
         {
             $imageObject = new mm\Info\Image;
@@ -119,6 +123,7 @@ class MkvManagerScraperTMDB extends MkvManagerScraper
                 }
             }
             $result[] = $imageObject;
+        }
         }
 
         return $result;

--- a/lib/mvc/controllers/movie.php
+++ b/lib/mvc/controllers/movie.php
@@ -39,6 +39,7 @@ class Movie extends \ezcMvcController
                     $mergedResult->title = $scrapResult->title;
                     $mergedResult->thumbnail = $scrapResult->thumbnail;
                     $mergedResult->productionYear = $scrapResult->productionYear;
+                    $mergedResult->releaseYear = $scrapResult->releaseYear;
                     $mergedResult->{"id_$identifier"} = $scrapResult->id;
                     $mergedResult->{"url_$identifier"} = $scrapResult->url;
                     $result->variables["results"][$resultHash] = $mergedResult;

--- a/lib/mvc/controllers/movie.php
+++ b/lib/mvc/controllers/movie.php
@@ -24,11 +24,16 @@ class Movie extends \ezcMvcController
         $query = $this->folder;
         $result = new \ezcMvcResult();
         $result->variables['page_title'] = "{$query} :: Search for Movie NFO :: MKV Manager";
+
+        $hasResults = false;
         foreach( array( 'allocine' => '\MkvManagerScraperAllocine', 'tmdb' => '\MkvManagerScraperTMDB' ) as $identifier => $scraperClass )
         {
             $scraper = new $scraperClass();
             $scrapResults = $scraper->searchMovies( $query );
 
+            if( $scrapResults !== false )
+            {
+            $hasResults = true;
             foreach( $scrapResults as $scrapResult )
             {
                 $resultHash = strtolower( "{$scrapResult->originalTitle} ({$scrapResult->productionYear})" );
@@ -60,7 +65,10 @@ class Movie extends \ezcMvcController
                     isset( $mergedResult->id_tmdb ) ? $mergedResult->id_tmdb : 'none'
                 );
             }
+            }
         }
+        if( !$hasResults )
+            $result->variables["results"] = array();
 
         return $result;
     }

--- a/templates/nfo/movie/search.php
+++ b/templates/nfo/movie/search.php
@@ -1,3 +1,4 @@
+<? if( count( $this->results ) > 0 ): ?>
 <table>
     <? foreach( $this->results as $result ): ?>
     <tr>
@@ -12,3 +13,6 @@
     </tr>
     <? endforeach ?>
 </table>
+<?else:?>
+<h3>No result. Sorry.</h3>
+<?endif?>

--- a/templates/nfo/movie/search.php
+++ b/templates/nfo/movie/search.php
@@ -3,7 +3,7 @@
     <tr>
         <td width="200"><img width="200" src="<?=$result->thumbnail?>" /></td>
         <td>
-            <h3><?= $result->originalTitle ?> (<?= $result->productionYear ?>)</h3>
+            <h3><?= $result->originalTitle ?> (<?= $result->releaseYear ?>)</h3>
             <?if ( isset( $result->url_allocine ) ):?><a href="<?=$result->url_allocine?>">See on allocine.fr</a><br /><?endif?>
             <?if ( isset( $result->url_tmdb ) ):?><a href="<?=$result->url_url_tmdb?>">See on tmdb.org</a><br /><?endif?>
             <br />


### PR DESCRIPTION
J'ai remarqué que l'année de production est assez souvent différente de l'année de sortie du film donc je propose de faire comme ça :) Ca permet aussi d'avoir des dates homogènes sachant que TMDB ne gère que l'année de sortie et pas l'année de production (à confirmer car je suis allé un peu vite)
